### PR TITLE
Fixed display in Firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,8 +15,19 @@
       svg text {
         font-family: sans-serif;
         text-anchor: middle;
-        alignment-baseline: central;
         pointer-events: none;
+      }
+
+      @supports (alignment-baseline: central) {
+        svg text {
+          alignment-baseline: central;
+        }
+      }
+
+      @supports not (alignment-baseline: central) {
+        svg text {
+          transform: translateY(0.1rem);
+        }
       }
 
       circle {cursor: pointer;}

--- a/main.js
+++ b/main.js
@@ -11,7 +11,7 @@ function render(N) {
         const y = -80 * Math.cos(phi)
         const R = 250 / (N + 12)
         add(`<circle data-i="${i}" cx=${x} cy=${y} r=${R} fill="#ddd"></circle>`)
-        add(`<text x=${x} y=${y} style="font-size: ${1.2*R}">${i}</text>`)
+        add(`<text x=${x} y=${y} style="font-size: ${1.2 * R}px">${i}</text>`)
     }
     document.querySelectorAll("circle").forEach(i=>{
         console.log(i.dataset.i);


### PR DESCRIPTION
- Added missing unit to font size. (Firefox does not support font-size without units)
- Added "very hacky" fallback to fix text positioning in Firefox. (alignment-baseline is not supported in Firefox)